### PR TITLE
Fix ZoomControls click events

### DIFF
--- a/src/pages/ContextExamples/ZoomControls/MapProvider.tsx
+++ b/src/pages/ContextExamples/ZoomControls/MapProvider.tsx
@@ -61,13 +61,14 @@ const MapProvider: FunctionComponent<MapProps> = ({
   }, [mapInstance, containerRef]);
 
   return (
-    <div ref={containerRef} className={styles.container}>
+    <>
+      <div ref={containerRef} className={styles.container} />
       {!!mapInstance && (
         <MapContext.Provider value={{ mapInstance }}>
           {children}
         </MapContext.Provider>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/pages/ContextExamples/ZoomControlsFullScreen/MapProvider.tsx
+++ b/src/pages/ContextExamples/ZoomControlsFullScreen/MapProvider.tsx
@@ -54,13 +54,14 @@ const MapProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   }, [mapInstance, containerRef]);
 
   return (
-    <div ref={containerRef} className={styles.container}>
+    <>
+      <div ref={containerRef} className={styles.container} />
       {!!mapInstance && (
         <MapContext.Provider value={{ mapInstance }}>
           {children}
         </MapContext.Provider>
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
In both [ZoomControls examples](https://maps.developers.amsterdam/?path=/story/react-context-examples-zoomcontrols--default) when you click on a Zoom button it also triggers a map click. This is because the zoom control buttons are children of the map container DOM element. Moving them to the same level as the map container resolves this.

The `!!mapInstance` conditional could also be wrapped around the whole return body.